### PR TITLE
Fix compilation error for two LLVM opt passes

### DIFF
--- a/libhlc/hlc.cpp
+++ b/libhlc/hlc.cpp
@@ -191,7 +191,7 @@ namespace libHLC
         // supported.
         initializeCodeGenPreparePass(Registry);
         initializeAtomicExpandPass(Registry);
-        initializeRewriteSymbolsPass(Registry);
+        initializeRewriteSymbolsLegacyPassPass(Registry);
         initializeWinEHPreparePass(Registry);
         initializeDwarfEHPreparePass(Registry);
         initializeSafeStackPass(Registry);
@@ -205,7 +205,7 @@ namespace libHLC
         initializeCodeGen(Registry);
         initializeLoopStrengthReducePass(Registry);
         initializeLowerIntrinsicsPass(Registry);
-        initializeUnreachableBlockElimPass(Registry);
+        initializeUnreachableBlockElimLegacyPassPass(Registry);
 
     }
 


### PR DESCRIPTION
- `initializeUnreachableBlockElimPass` had been renamed as `initializeUnreachableBlockElimLegacyPassPass` on 7/8/16, commit # 302c35d62
- `initializeRewriteSymbolsPass` had been renamed as `initializeRewriteSymbolLegacyPassPass` on 7/25/16, commit # b3391842c

proposing changing libHLC to reflect changes upstream.
